### PR TITLE
Add flake8 to pre-commit and fix failing checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,8 @@ repos:
     hooks:
       - id: black
         language_version: python3
-
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [Flake8-pyproject]

--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -200,7 +200,8 @@ class PerturbationExperiment(BaseExperiment):
                         else:
                             if len(row) != total_exps:
                                 raise ValueError(
-                                    f"For key '{key}', the inner list length {len(row)}, but the total experiment {total_exps}"
+                                    f"For key '{key}', the inner list length {len(row)}, but the "
+                                    f"total experiment {total_exps}"
                                 )
                             new_list.append(row[indx])
                     result[key] = new_list
@@ -211,7 +212,8 @@ class PerturbationExperiment(BaseExperiment):
                     else:
                         if len(value) != total_exps:
                             raise ValueError(
-                                f"For key '{key}', the inner list length {len(value)}, but the total experiment {total_exps}"
+                                f"For key '{key}', the inner list length {len(value)}, but the "
+                                f"total experiment {total_exps}"
                             )
                         result[key] = value[indx]
             # Scalar, string, etc so return as is

--- a/tests/test_base_experiment.py
+++ b/tests/test_base_experiment.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 from experiment_generator.base_experiment import BaseExperiment
 

--- a/tests/test_config_updater.py
+++ b/tests/test_config_updater.py
@@ -1,4 +1,3 @@
-import sys
 import pytest
 from pathlib import Path
 from experiment_generator.config_updater import ConfigUpdater

--- a/tests/test_experiment_generator.py
+++ b/tests/test_experiment_generator.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 import sys
 from experiment_generator.experiment_generator import ExperimentGenerator as eg, VALID_MODELS
 

--- a/tests/test_f90nml_updater.py
+++ b/tests/test_f90nml_updater.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import math
 import numpy as np
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,4 @@
-from pathlib import Path
 import sys
-import pytest
 import experiment_generator.main as main_module
 
 VALID_MODELS = ["access-om2", "access-om3"]

--- a/tests/test_mom6_input_updater.py
+++ b/tests/test_mom6_input_updater.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from experiment_generator.mom6_input_updater import Mom6InputUpdater
 from experiment_generator.tmp_parser.mom6_input import read_mom_input
 

--- a/tests/test_nuopc_runconfig_updater.py
+++ b/tests/test_nuopc_runconfig_updater.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-import yaml
 from experiment_generator.nuopc_runconfig_updater import NuopcRunConfigUpdater
 from experiment_generator.tmp_parser.nuopc_config import read_nuopc_config
 
@@ -13,7 +11,7 @@ def test_update_runconfig_params_updates_and_removes(tmp_path):
     runconfig_path.write_text(
         """
 PELAYOUT_attributes::
-     atm_ntasks = 364 
+     atm_ntasks = 364
      atm_nthreads = 2
      atm_pestride = 2
      atm_rootpe = 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,3 @@
-import os
-import warnings
-import pytest
-
 from experiment_generator.utils import update_config_entries
 
 


### PR DESCRIPTION
Given that `flake8` is run in the CI, it may be prudent to add it also to the pre-commit hooks. This PR does that and fixes failing `flake8` checks