### PR TITLE
Warn instead of error when Control_Experiment block is missing

### DIFF
--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -71,8 +71,12 @@ class PerturbationExperiment(BaseExperiment):
         Update files for the control branch (name held in `self.control_branch_name`).
         """
         control_data = self.indata.get("Control_Experiment")
-        if not control_data:
-            raise ValueError("No Control_Experiment block provided in the input yaml file.")
+        if control_data is None:
+            warnings.warn(
+                "No Control_Experiment block provided in the input YAML file. " "Skipping control branch updates.",
+                UserWarning,
+            )
+            return
 
         # Ensure we are on the control branch
         branch_names = {i.name for i in self.gitrepository.repo.branches}

--- a/tests/test_perturbation_experiment.py
+++ b/tests/test_perturbation_experiment.py
@@ -97,7 +97,7 @@ def test_manage_control_expt_no_control_data(tmp_path):
         "repository_directory": "test_repo",
     }
     expt = pert_exp(tmp_path, indata)
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning, match="No Control_Experiment block provided"):
         expt.manage_control_expt()
 
 


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/access-experiment-generator/issues/26


This PR updates `manage_control_expt` to handle the absence of a `Control_Experiment` block. Previously, it raised a ValueError if the block was missing, which unnecessarily stopped execution in cases where modifying a control experiment is optional.