### PR TITLE
Add support for esm1.5/1.6 configurations

### DIFF
--- a/src/experiment_generator/experiment_generator.py
+++ b/src/experiment_generator/experiment_generator.py
@@ -3,7 +3,7 @@ from .perturbation_experiment import PerturbationExperiment
 from .base_experiment import BaseExperiment
 
 # can be extended to include other models
-VALID_MODELS = ("access-om2", "access-om3")
+VALID_MODELS = ("access-esm1.5", "access-esm1.6", "access-om2", "access-om3")
 
 
 class ExperimentGenerator(BaseExperiment):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,7 @@
 import sys
 import experiment_generator.main as main_module
+from experiment_generator.experiment_generator import VALID_MODELS
 import pytest
-
-VALID_MODELS = ["access-om2", "access-om3"]
 
 
 def test_main_runs_with_i_flag(tmp_path, monkeypatch):


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/access-experiment-generator/issues/28

Extend the valid models to include "access-esm1.5" and  "access-esm1.6"