### PR TITLE
34 refactor expt paths

### DIFF
--- a/examples/Experiment_generator_example.yaml
+++ b/examples/Experiment_generator_example.yaml
@@ -5,7 +5,7 @@
 model_type: access-om2 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
 repository_url: git@github.com:ACCESS-NRI/access-om2-configs.git
 start_point: "fce24e3" # Control commit hash for new branches
-test_path: prototype-0.1.0 # All control and perturbation experiment repositories will be created here; can be relative or absolute (user-defined)
+test_path: prototype-0.1.0 # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)
 repository_directory: 1deg_jra55_ryf # Local directory name for the central repository (user-defined)
 
 control_branch_name: ctrl

--- a/examples/Experiment_generator_example.yaml
+++ b/examples/Experiment_generator_example.yaml
@@ -2,10 +2,10 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-om2 # Specify the model ("access-om2" or "access-om3")
+model_type: access-om2 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
 repository_url: git@github.com:ACCESS-NRI/access-om2-configs.git
 start_point: "fce24e3" # Control commit hash for new branches
-test_path: prototype-0.1.0 # Relative path for the central repository (control and perturbation) (user-defined)
+test_path: prototype-0.1.0 # All control and perturbation experiment repositories will be created here; can be relative or absolute (user-defined)
 repository_directory: 1deg_jra55_ryf # Local directory name for the central repository (user-defined)
 
 control_branch_name: ctrl

--- a/src/experiment_generator/base_experiment.py
+++ b/src/experiment_generator/base_experiment.py
@@ -11,16 +11,15 @@ class BaseExperiment:
 
     def __init__(self, indata: dict) -> None:
         self.indata = indata
-        self.dir_manager = Path.cwd()
 
         # General experiment setup
-        self.test_path = Path(indata.get("test_path", "experiment_generator_test_path"))
+        self.test_path = Path(indata.get("test_path", ".")).expanduser()
         self.model_type = indata.get("model_type", False)
 
         # Repository setup
         self.repository = indata.get("repository_url")
         self.repo_dir = indata.get("repository_directory")
-        self.directory = Path(self.dir_manager) / self.test_path / self.repo_dir
+        self.directory = (self.test_path / self.repo_dir).resolve()
         self.existing_branch = indata.get("existing_branch", None)
         self.control_branch_name = indata.get("control_branch_name", False)
         self.keep_uuid = indata.get("keep_uuid", False)

--- a/src/experiment_generator/main.py
+++ b/src/experiment_generator/main.py
@@ -15,7 +15,7 @@ def main():
     Command-line Arguments:
         -i, --input-yaml-file (str, optional):
             Path to the YAML file specifying parameter values for the experiment runs.
-            Defaults to 'Experiment_manager.yaml' if it exists.
+            Defaults to 'Experiment_generator.yaml' if it exists.
     """
 
     parser = argparse.ArgumentParser(

--- a/src/experiment_generator/main.py
+++ b/src/experiment_generator/main.py
@@ -21,7 +21,7 @@ def main():
     parser = argparse.ArgumentParser(
         description=(
             "Manage ACCESS experiments using configurable YAML input.\n"
-            "If no YAML file is specified, the tool will look for 'Experiment_manager.yaml' "
+            "If no YAML file is specified, the tool will look for 'Experiment_generator.yaml' "
             "in the current directory.\n"
             "If that file is missing, you must specify one with -i / --input-yaml-file."
         ),
@@ -34,18 +34,18 @@ def main():
         type=str,
         help=(
             "Path to the YAML file specifying parameter values for experiment runs.\n"
-            "Defaults to 'Experiment_manager.yaml' if present in the current directory."
+            "Defaults to 'Experiment_generator.yaml' if present in the current directory."
         ),
     )
 
     args = parser.parse_args()
     if args.input_yaml_file:
         input_yaml = args.input_yaml_file
-    elif os.path.exists("Experiment_manager.yaml"):
-        input_yaml = "Experiment_manager.yaml"
+    elif os.path.exists("Experiment_generator.yaml"):
+        input_yaml = "Experiment_generator.yaml"
     else:
         parser.error(
-            "No YAML file specified and 'Experiment_manager.yaml' not found.\n"
+            "No YAML file specified and 'Experiment_generator.yaml' not found.\n"
             "Please provide one using -i / --input-yaml-file."
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,5 +77,5 @@ def test_main_errors_when_no_yaml_provided_and_default_missing(tmp_path, monkeyp
     captured = capsys.readouterr()
 
     err = captured.err
-    assert "Experiment_manager.yaml" in err
+    assert "Experiment_generator.yaml" in err
     assert "-i / --input-yaml-file" in err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,7 +34,7 @@ model_type: {VALID_MODELS[0]}
 
 
 def test_main_uses_default_yaml_when_present(tmp_path, monkeypatch):
-    default_yaml = tmp_path / "Experiment_manager.yaml"
+    default_yaml = tmp_path / "Experiment_generator.yaml"
     default_yaml.write_text(
         f"""
 repository_directory: test_repo


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/access-experiment-generator/issues/34

- `test_path`: Users can now specify absolute, relative or `~` paths for experiments.
- Change the default yaml to be `Experiment_generator.yaml` instead of `Experiment_manager.yaml.`