### PR TITLE
Add a perturbation example showing list-of-dicts and list-of-lists (broadcast & per-branch)

### DIFF
--- a/examples/Example_esm1.6_submodules.yaml
+++ b/examples/Example_esm1.6_submodules.yaml
@@ -1,0 +1,141 @@
+# Experiment Configuration File
+# This file sets up parameters for both the control and perturbation experiments.
+# Adjust the settings below as needed for your environment and model.
+
+model_type: access-esm1.6 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+repository_url: git@github.com:ACCESS-NRI/access-esm1.6-configs.git
+start_point: "61b5e1c" # Control commit hash for new branches
+test_path: prototype-0.3.0-esm1.6-submodules # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)
+repository_directory: dev-preindustrial # Local directory name for the central repository (user-defined)
+
+control_branch_name: ctrl
+
+Control_Experiment:
+# No changes to apply for the control branch
+
+Perturbation_Experiment:
+  Parameter_block1:
+    # This block defines two perturbation branches that vary per-submodel cpu counts.
+    # You can extend this to change other parameters (e.g., exe, input files, etc.).
+    #
+    # Notes:
+    # - Under a list, such as `submodels`, one must provide the entire list of submodels
+    #   even if only one submodel is being changed.
+    # - If a parameter value is a single scalar/string, it is used for all branches.
+    # - If a parameter value is a list whose length == number of branches, the i-th
+    #   element is used for the i-th branch (index selection).
+    #
+    # About nested lists for inputs:
+    # - A leading "- -" indicates a single (nested) list, i.e. one list of multiple
+    #   paths applied as-is (broadcast) to all branches.
+    # - To supply different input lists per branch, provide a *list of lists* where
+    #   the outer list length equals the number of branches.
+
+    # Example: a single nested list (broadcast to all branches)
+    # input:
+    #   - - /path/to/kmt.nc
+    #     - /path/to/grid.nc
+    #     - /path/to/iceberg_flux.nc
+    #
+    # Example: branch-specific nested lists (outer list length == number of branches)
+    # input:
+    #   - - /path/to/kmt.nc
+    #     - /path/to/grid.nc
+    #     - /path/to/iceberg_flux.nc
+    #   - - /path/to/kmt2.nc
+    #     - /path/to/grid2.nc
+    #     - /path/to/iceberg_flux2.nc
+
+    branches: 
+      - perturb_1
+      - perturb_2
+
+    config.yaml:
+      submodels:
+        - name: atmosphere
+          model: um
+          ncpus:
+            - 208
+            - 416
+          exe: um_hg3.exe
+          input:
+              # single nested list -> same files used by all branches
+              # Aerosols
+            - - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/OCFF_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/BC_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/scycl_1850_cmip7.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/pre-industrial/atmosphere/aerosol/global.N96/2025.06.04/Bio_1850_cmip7.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+              # Forcing
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
+              # Land
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2025.06.06/modis_phenology_csiro_nophase.txt
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/share/atmosphere/land/biogeochemistry/resolution_independent/2024.12.18/pftlookup_cable3.csv
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+              # Spectral
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+              # Grids
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+              # STASH
+              - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
+
+        - name: ocean
+          model: mom
+          ncpus:
+            - 196
+            - 392
+          exe: mom5_access_cm 
+          input:
+              # Biogeochemistry
+            - - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+              # Tides
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+              # Shortwave
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/shortwave_penetration/global.1deg/2025.06.23/ssw_atten_depth.nc
+              # Grids
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/grid_spec.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/ocean_mosaic.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/mosaic/global.1deg/2025.07.29/ocean_hgrid.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/bathymetry/global.1deg/2025.07.29/topog.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ocean/grids/vertical/global.1deg/2025.07.29/ocean_vgrid.nc
+
+        - name: ice
+          model: cice5
+          ncpus:
+            - 12
+            - 24
+          exe: cice_access-esm1.6_360x300_12x1_12p.exe
+          input:
+              # Grids
+            - - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ice/grids/global.1deg/2025.07.29/kmt.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/ice/grids/global.1deg/2025.07.29/grid.nc
+              # Iceberg flux
+              - /g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/share/ice/iceberg/global.1deg/2024.11.08/lice_discharge_iceberg.nc
+
+        - name: coupler
+          model: oasis
+          ncpus: 0
+          input:
+              # Grids
+            - - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/grids/global.oi_1deg.a_N96/2025.07.29/grids.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/grids/global.oi_1deg.a_N96/2025.07.29/areas.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+              # Remapping weights
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+              - /g/data/vk83/configurations/inputs/access-esm1p6/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2025.08.06/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc


### PR DESCRIPTION
This is an example to demonstrate list of dicts, list of lists usage, in this example,

- `submodels` as a list of dicts
- index-selected per-branch parameter values (e.g. `ncpus: [208, 416]`)
- broadcasting of single scalars/strings (e.g., `exe: um_hg3.exe`)
- nested list inputs:
  - single nested list -> broadcast to all branches
  - list of nested lists -> per-branch inputs