### PR TITLE
match exact variable name in update

### DIFF
--- a/src/experiment_generator/f90nml_updater.py
+++ b/src/experiment_generator/f90nml_updater.py
@@ -10,6 +10,7 @@ It supports parameter additions, updates, deletions, and specific logic
 from pathlib import Path
 import numpy as np
 import f90nml
+import re
 
 
 class F90NamelistUpdater:
@@ -114,7 +115,8 @@ def format_nml_params(nml_path: str, param_dict: dict) -> None:
             for idx, line in enumerate(fileread):
                 if line.lstrip().startswith("!"):
                     continue
-                if tmp_param in line:
+                words = [w for w in re.split(r"[^a-zA-Z0-9_]+", line) if w]
+                if tmp_param in words:
                     fileread[idx] = f"    {tmp_param} = {tmp_values}\n"
                     break
 

--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -12,6 +12,7 @@ from .nuopc_runseq_updater import NuopcRunseqUpdater
 from .om2_forcing_updater import Om2ForcingUpdater
 from .common_var import REMOVED, BRANCH_KEY
 from collections.abc import Mapping, Sequence, Hashable
+import os
 
 
 @dataclass
@@ -57,7 +58,7 @@ class PerturbationExperiment(BaseExperiment):
         Apply a dict of `{filename: parameters}` to different config files.
         """
         for filename, params in file_params.items():
-            if filename.endswith("_in") or filename.endswith(".nml"):
+            if filename.endswith("_in") or filename.endswith(".nml") or os.path.basename(filename) == "namelists":
                 self.f90namelistupdater.update_nml_params(params, filename)
             elif filename.endswith(".yaml"):
                 self.configupdater.update_config_params(params, filename)

--- a/tests/test_f90nml_updater.py
+++ b/tests/test_f90nml_updater.py
@@ -127,3 +127,18 @@ def test_format_nml_params_skips_comment_lines(tmp_path):
     assert lines[1].startswith("! flag")
     # assignment line updated
     assert "flag = .true." in lines[2]
+
+
+def test_format_nml_params_exact_varname_match(tmp_path):
+    nml_file = tmp_path / "test.nml"
+    nml_file.write_text("&dummy\n" "    ! days = 99\n" "    days = 30\n" "    days_to_increment = 5\n" "/\n")
+
+    format_nml_params(
+        nml_file.as_posix(),
+        {"dummy": {"days": 31}},
+    )
+
+    lines = nml_file.read_text().splitlines()
+    assert lines[1].strip() == "! days = 99"
+    assert lines[2].strip() == "days = 31"
+    assert lines[3].strip() == "days_to_increment = 5"


### PR DESCRIPTION
This applies a stricter search criteria when updating lines in the nml. Before, the line would be updated if the line contained the variable to be updated, e.g. if the variable to be updated is "days", the "days_to_increment" would also be updated.

The stricter search criteria ensures that only the whole variable matches.

Also makes sure the nml updater gets applied for files called `namelists` e.g. in um.