### PR TITLE
Directly use Payu api to extract `VALID_MODELS` instead of hard copy

### DIFF
--- a/src/experiment_generator/experiment_generator.py
+++ b/src/experiment_generator/experiment_generator.py
@@ -1,9 +1,11 @@
 from payu.branch import clone
+from payu.models import index as model_index
 from .perturbation_experiment import PerturbationExperiment
 from .base_experiment import BaseExperiment
 
-# can be extended to include other models
-VALID_MODELS = ("access-esm1.5", "access-esm1.6", "access-om2", "access-om3")
+# directly use Payu api
+# https://github.com/payu-org/payu/blob/master/payu/subcommands/list_cmd.py
+VALID_MODELS = tuple(model_index)
 
 
 class ExperimentGenerator(BaseExperiment):


### PR DESCRIPTION
Closes #58

