### PR TITLE
Rewrite examples' model_type comments to follow #59

### DIFF
--- a/examples/Example_diag_table_source.yaml
+++ b/examples/Example_diag_table_source.yaml
@@ -2,7 +2,7 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-om3 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-om3  # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-om3-configs.git
 start_point: "52bf0b6" # Control commit hash for new branches
 test_path: prototype-0.4-dict-of-dicts # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)

--- a/examples/Example_esm1.6_submodules.yaml
+++ b/examples/Example_esm1.6_submodules.yaml
@@ -2,7 +2,7 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-esm1.6 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-esm1.6  # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-esm1.6-configs.git
 start_point: "61b5e1c" # Control commit hash for new branches
 test_path: prototype-0.3.0-esm1.6-submodules # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)

--- a/examples/Example_om2_forcing.yaml
+++ b/examples/Example_om2_forcing.yaml
@@ -2,7 +2,7 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-om2 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-om2  # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-om2-configs.git
 start_point: "6b315e4" # Control commit hash for new branches
 test_path: prototype-0.2.0-om2-forcing # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)

--- a/examples/Example_preserve_parameters.yaml
+++ b/examples/Example_preserve_parameters.yaml
@@ -2,7 +2,7 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-om3 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-om3  # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-esm1.6-configs.git
 start_point: "61b5e1c" # Control commit hash for new branches
 test_path: prototype-0.5.0-preserve-parameters # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)

--- a/examples/Example_remove_parameters.yaml
+++ b/examples/Example_remove_parameters.yaml
@@ -10,7 +10,7 @@
 # - Use 'REMOVE' (as a literal string) to prune a key or element.
 # - Use '~', 'null' or leave the value blank, to explicitly set a parameter to None (kept in config).
 
-model_type: access-om3 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-om3 # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-om3-configs.git
 start_point: "52bf0b6" # Control commit hash for new branches
 test_path: prototype-0.2.0-remove-parameters # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)

--- a/examples/Experiment_generator_example.yaml
+++ b/examples/Experiment_generator_example.yaml
@@ -2,7 +2,7 @@
 # This file sets up parameters for both the control and perturbation experiments.
 # Adjust the settings below as needed for your environment and model.
 
-model_type: access-om2 # Specify the model ("access-om2", "access-om3", "access-esm1.5", or "access-esm1.6")
+model_type: access-om2 # available models can be checked via `payu list`
 repository_url: git@github.com:ACCESS-NRI/access-om2-configs.git
 start_point: "fce24e3" # Control commit hash for new branches
 test_path: prototype-0.1.0 # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)


### PR DESCRIPTION
Companion to #59

The `model_type` can now be set to any supported by `Payu`. Updated the examples to remove the old inline comments after `model_type` and replaced them with:

```yaml
# available models can be checked via `payu list`
```