### PR TITLE
Avoid iterating characters when value is a string in the nuopc.runconfig tmp_parser

### DIFF
--- a/src/experiment_generator/tmp_parser/nuopc_config.py
+++ b/src/experiment_generator/tmp_parser/nuopc_config.py
@@ -141,4 +141,4 @@ def write_nuopc_config(config: dict, file: Path):
                     stream.write("  " + label + " = " + convert_to_string(value) + "\n")
                 stream.write("::\n\n")
             else:
-                stream.write(key + ": " + " ".join(map(convert_to_string, item)) + "\n")
+                stream.write(key + ": " + convert_to_string(item) + "\n")


### PR DESCRIPTION
Closes #70 

Instead of `join` values, treat values as singles

