### PR TITLE
Fix - Make positional REMOVE consistent and safe across multiple runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-# skip remove state files
-.expt_remove_states/

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# skip remove state files
+.expt_remove_states/

--- a/src/experiment_generator/common_var.py
+++ b/src/experiment_generator/common_var.py
@@ -4,6 +4,9 @@ from collections.abc import Sequence
 BRANCH_KEY = "branches"
 REMOVED = "REMOVE"
 PRESERVED = "PRESERVE"
+# Directory name to store REMOVE state files
+# Dont change this variable name as it is hard-coded to .gitignore
+REMOVE_STATE_DIR = ".expt_remove_states"
 
 
 def _is_removed_str(x) -> bool:

--- a/src/experiment_generator/common_var.py
+++ b/src/experiment_generator/common_var.py
@@ -5,7 +5,6 @@ BRANCH_KEY = "branches"
 REMOVED = "REMOVE"
 PRESERVED = "PRESERVE"
 # Directory name to store REMOVE state files
-# Dont change this variable name as it is hard-coded to .gitignore
 REMOVE_STATE_DIR = ".expt_remove_states"
 
 

--- a/src/experiment_generator/config_updater.py
+++ b/src/experiment_generator/config_updater.py
@@ -22,7 +22,7 @@ class ConfigUpdater:
         """
         self.directory = directory
 
-    def update_config_params(self, param_dict: dict, target_file: Path) -> None:
+    def update_config_params(self, param_dict: dict, target_file: Path, state: dict) -> None:
         """
         Update `config.yaml` parameters using values from the input dictionary.
 
@@ -48,7 +48,7 @@ class ConfigUpdater:
         param_dict["jobname"] = self.directory.name
 
         # Apply updates to the config.yaml file
-        update_config_entries(file_read, param_dict)
+        update_config_entries(file_read, param_dict, pop_key=True, path=str(target_file), state=state)
 
         # write to the config.yaml file
         write_yaml(file_read, nml_path.as_posix())

--- a/src/experiment_generator/f90nml_updater.py
+++ b/src/experiment_generator/f90nml_updater.py
@@ -65,8 +65,9 @@ class F90NamelistUpdater:
                             if "dynamics_nml" in nml_all:
                                 nml_all["dynamics_nml"].pop("cosw", None)
                                 nml_all["dynamics_nml"].pop("sinw", None)
-                                if not nml_all["dynamics_nml"]:
-                                    nml_all.pop("dynamics_nml", None)
+                                # TODO: consider removing empty dynamics_nml group?
+                                # if not nml_all["dynamics_nml"]:
+                                #     nml_all.pop("dynamics_nml", None)
 
                         elif _is_preserved_str(turning_angle) or turning_angle is None:
                             dyn = nml_all.get("dynamics_nml", {})

--- a/src/experiment_generator/mom6_input_updater.py
+++ b/src/experiment_generator/mom6_input_updater.py
@@ -18,6 +18,7 @@ class Mom6InputUpdater:
         self,
         param_dict: dict,
         target_file: str,
+        state: dict,
     ) -> None:
         """
         Updates parameters and overwrites the MOM6 input file.
@@ -33,7 +34,8 @@ class Mom6InputUpdater:
 
         # Update the parameters
         # Note: This will remove keys with value "REMOVE" only
-        update_config_entries(base_params, param_dict, pop_key=True)
+        # stored state is dummy in this updater since there is no list handling here
+        update_config_entries(base_params, param_dict, pop_key=True, path=str(target_file), state=state)
 
         # Write the updated parameters back to the MOM6 input file
         write_mom_input(raw_lines, base_params, nml_path)

--- a/src/experiment_generator/nuopc_runconfig_updater.py
+++ b/src/experiment_generator/nuopc_runconfig_updater.py
@@ -24,6 +24,7 @@ class NuopcRunConfigUpdater:
         self,
         param_dict: dict,
         target_file: str,
+        state: dict,
     ) -> None:
         """
         Updates parameters and overwrites the `nuopc.runconfig` file.
@@ -34,5 +35,6 @@ class NuopcRunConfigUpdater:
         nml_path = self.directory / target_file
 
         file_read = read_nuopc_config(nml_path)
-        update_config_entries(file_read, param_dict)
+        # stored state is dummy in this updater since there is no list handling here
+        update_config_entries(file_read, param_dict, pop_key=True, path=str(target_file), state=state)
         write_nuopc_config(file_read, nml_path)

--- a/src/experiment_generator/om2_forcing_updater.py
+++ b/src/experiment_generator/om2_forcing_updater.py
@@ -47,7 +47,7 @@ class Om2ForcingUpdater:
             for k in keys_to_drop:
                 updates.pop(k, None)
 
-            update_config_entries(base, updates, pop_key=True, path=str(target_file), state=state)
+            update_config_entries(base, updates, path=str(target_file), state=state)
 
         write_json(file_read, forcing_path)
 

--- a/src/experiment_generator/om2_forcing_updater.py
+++ b/src/experiment_generator/om2_forcing_updater.py
@@ -20,6 +20,7 @@ class Om2ForcingUpdater:
         self,
         param_dict: dict,
         target_file: Path,
+        state: dict,
     ) -> None:
         forcing_path = self.directory / target_file
         file_read = read_json(forcing_path)
@@ -46,7 +47,7 @@ class Om2ForcingUpdater:
             for k in keys_to_drop:
                 updates.pop(k, None)
 
-            update_config_entries(base, updates)
+            update_config_entries(base, updates, pop_key=True, path=str(target_file), state=state)
 
         write_json(file_read, forcing_path)
 

--- a/src/experiment_generator/state_store.py
+++ b/src/experiment_generator/state_store.py
@@ -1,0 +1,45 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from .common_var import REMOVE_STATE_DIR
+
+
+@dataclass
+class RemoveStateStore:
+    """
+    Record REMOVE values for each positional REMOVE marker under a specific path.
+    Hence a rerun removes the same items as before.
+    """
+
+    root_dir: Path
+    remove_state_dirname: str = REMOVE_STATE_DIR
+
+    def _state_dir(self) -> Path:
+        """
+        State directory path.
+        """
+        d = self.root_dir / self.remove_state_dirname
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def state_path(self, branch_name: str) -> Path:
+        """
+        State file path for a given branch name.
+        """
+        return self._state_dir() / f"{branch_name}.json"
+
+    def load_state(self, branch_name: str) -> dict:
+        """
+        Load state for a given branch from a file.
+        """
+        fpath = self.state_path(branch_name)
+        if not fpath.exists():
+            return {}
+        return json.loads(fpath.read_text())
+
+    def save_state(self, branch_name: str, state: dict) -> None:
+        """
+        Save state for a given branch to a file.
+        """
+        fpath = self.state_path(branch_name)
+        fpath.write_text(json.dumps(state, indent=2))

--- a/src/experiment_generator/utils.py
+++ b/src/experiment_generator/utils.py
@@ -11,10 +11,15 @@ This module provides helper functions
 
 from collections.abc import Mapping, Sequence
 from .common_var import _is_removed_str, _is_preserved_str, _is_seq
+from copy import deepcopy
 
 
 def _path_join(path: str, key: str) -> str:
-    return f"{path}.{key}" if path else key
+    if not path:
+        return str(key)
+    if str(key).startswith("["):
+        return f"{path}{key}"
+    return f"{path}.{key}"
 
 
 def _remove_state_key(path: str, index: int) -> str:
@@ -106,6 +111,18 @@ def _clean_removes(x, *, pop_key: bool) -> object:
     return x
 
 
+def _remove_first_occurrence(seq: list, target) -> bool:
+    """
+    Remove the first element equal to target from seq.
+    Returns True if removed, False if not found.
+    """
+    for i, x in enumerate(seq):
+        if x == target:
+            seq.pop(i)
+            return True
+    return False
+
+
 def _merge_lists_positional(
     base_list: list, change_list: list, *, path: str, state: dict | None, pop_key: bool
 ) -> list | None:
@@ -137,25 +154,31 @@ def _merge_lists_positional(
     # if change_list and all(_is_removed_str(c) for c in change_list):
     #     return None
 
-    out = []
-    max_len = max(len(base_list), len(change_list))
+    base_key = f"{path}::BASE"
+    if base_key not in state:
+        # deepcopy to avoid later mutations affecting the snapshot
+        state[base_key] = deepcopy(base_list)
+    base0 = state[base_key]  # stable baseline for all runs
 
-    # pre-compute "remembered removals" for this list path
-    remembered_removals = []
-    prefix = f"{path}::REMOVE["
-    for key, value in state.items():
-        if isinstance(key, str) and key.startswith(prefix):
-            remembered_removals.append(value)
+    out = type(base_list)()
+    max_len = max(len(base0), len(change_list))
+
+    # Collect removal targets in order (one per REMOVE marker)
+    removal_targets = []
 
     # walk both lists by index, building a new list.
     for i in range(max_len):
-        have_base = i < len(base_list)
+        have_base = i < len(base0)
+        have_base_cur = i < len(base_list)
         have_change = i < len(change_list)
 
         if not have_change:
             # keep remainder of base as-is
             if have_base:
-                out.append(base_list[i])
+                if have_base_cur and isinstance(base_list[i], Mapping):
+                    out.append(base_list[i])
+                else:
+                    out.append(base0[i])
             continue
 
         c = change_list[i]
@@ -169,7 +192,10 @@ def _merge_lists_positional(
 
         if _is_preserved_str(c):
             if have_base:
-                out.append(base_list[i])
+                if have_base_cur and isinstance(base_list[i], Mapping):
+                    out.append(base_list[i])
+                else:
+                    out.append(base0[i])
             # if no base slot, do nothing (don't append "PRESERVE")
             continue
 
@@ -177,27 +203,22 @@ def _merge_lists_positional(
         if _is_removed_str(c):
             state_key = _remove_state_key(path, i)
             if state_key not in state and have_base:
-                # first time record what is being removed at this position
-                state[state_key] = base_list[i]
-                remembered_removals.append(base_list[i])
-
-            if have_base:
-                out.append(base_list[i])
-            # omit base[i] (i.e. don't append anything)
+                state[state_key] = base0[i]
+            if state_key in state:
+                removal_targets.append(state[state_key])
             continue
 
         # If both sides exist and are mappings, recursively merge
-        if have_base and isinstance(base_list[i], Mapping) and isinstance(c, Mapping):
-            merged = dict(base_list[i])  # shallow copy
+        if have_base and isinstance(base0[i], Mapping) and isinstance(c, Mapping):
+            merged = base_list[i]
             update_config_entries(merged, c, pop_key=pop_key, path=_path_join(path, f"[{i}]"), state=state)
-            # If merging produced an empty mapping and pop_key=True, drop the slot
             if not merged and pop_key:
                 continue
             out.append(merged)
             continue
 
         # If both sides exist and are lists, recursively merge lists
-        if have_base and isinstance(base_list[i], list) and isinstance(c, list):
+        if have_base_cur and isinstance(base_list[i], list) and isinstance(c, list):
             out.append(
                 _merge_lists_positional(base_list[i], c, path=_path_join(path, f"[{i}]"), state=state, pop_key=pop_key)
             )
@@ -210,9 +231,9 @@ def _merge_lists_positional(
             continue
         out.append(cleaned)
 
-    if remembered_removals:
-        # second pass: remove any remembered removals that may have shifted position
-        out = [x for x in out if x not in remembered_removals]
+    # Remove exactly one occurrence per remembered removal marker.
+    for target in removal_targets:
+        _remove_first_occurrence(out, target)
 
     return out
 
@@ -240,7 +261,9 @@ def update_config_entries(
        - If k is absent, it was removed during cleaning, so remove it from base.
 
     Update:
-        support state store for remembering positional REMOVE markers across runs
+        support state store for
+            - remembering positional REMOVE markers across runs,
+            - preserving existing formatting by in-place list updates.
     """
     if state is None:
         state = {}
@@ -262,13 +285,26 @@ def update_config_entries(
         if isinstance(base.get(k), list) and isinstance(v, list):
             merged = _merge_lists_positional(base[k], v, path=key_path, state=state, pop_key=pop_key)
             # if merge returned None -> delete key
-            if merged is None:
+            if merged is None or (pop_key and isinstance(merged, list) and len(merged) == 0):
                 base.pop(k, None)
                 continue
-            if pop_key and isinstance(merged, list) and len(merged) == 0:
-                base.pop(k, None)
-            else:
-                base[k] = merged
+
+            # inplace update to preserve formatting and comments
+            base_list = base[k]
+
+            # overwrite existing slots
+            n = min(len(base_list), len(merged))
+            for i in range(n):
+                base_list[i] = merged[i]
+
+            # append new items
+            for i in range(len(base_list), len(merged)):
+                base_list.append(merged[i])
+
+            # remove extra old items
+            while len(base_list) > len(merged):
+                base_list.pop()
+
             continue
 
         cleaned = _clean_removes({k: v}, pop_key=pop_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,32 +79,32 @@ class _RecorderBase:
 
 
 class F90Recorder(_RecorderBase):
-    def update_nml_params(self, params, filename):
+    def update_nml_params(self, params, filename, state=None, **kwargs):
         self._record("update_nml_params", params, filename)
 
 
 class PayuconfigRecorder(_RecorderBase):
-    def update_config_params(self, params, filename):
+    def update_config_params(self, params, filename, state=None, **kwargs):
         self._record("update_config_params", params, filename)
 
 
 class RunconfigRecorder(_RecorderBase):
-    def update_runconfig_params(self, params, filename):
+    def update_runconfig_params(self, params, filename, state=None, **kwargs):
         self._record("update_runconfig_params", params, filename)
 
 
 class Mom6Recorder(_RecorderBase):
-    def update_mom6_params(self, params, filename):
+    def update_mom6_params(self, params, filename, state=None, **kwargs):
         self._record("update_mom6_params", params, filename)
 
 
 class RunseqRecorder(_RecorderBase):
-    def update_nuopc_runseq(self, params, filename):
+    def update_nuopc_runseq(self, params, filename, state=None, **kwargs):
         self._record("update_nuopc_runseq", params, filename)
 
 
 class Om2forcingRecorder(_RecorderBase):
-    def update_forcing_params(self, params, filename):
+    def update_forcing_params(self, params, filename, state=None, **kwargs):
         self._record("update_forcing_params", params, filename)
 
 

--- a/tests/test_common_var.py
+++ b/tests/test_common_var.py
@@ -1,0 +1,76 @@
+import pytest
+
+from experiment_generator.common_var import (
+    REMOVED,
+    PRESERVED,
+    _is_removed_str,
+    _is_preserved_str,
+    _is_seq,
+)
+
+
+def test_is_removed_str_true():
+    assert _is_removed_str(REMOVED) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        PRESERVED,  # other marker
+        "REMOVE ",  # similar but not exact
+        " ",  # empty string
+        None,  # None value
+        1,  # integer
+        ["REMOVE"],  # list
+    ],
+)
+def test_is_removed_str_false(value):
+    assert _is_removed_str(value) is False
+
+
+def test_is_preserved_str_true():
+    assert _is_preserved_str(PRESERVED) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        REMOVED,  # other marker
+        "PRESERVE ",  # similar but not exact
+        " ",  # empty string
+        None,  # None value
+        1,  # integer
+        ["PRESERVE"],  # list
+    ],
+)
+def test_is_preserved_str_false(value):
+    assert _is_preserved_str(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [],  # list
+        [1, 2, 3],  # list with integers
+        (),  # tuple
+        ("a", "b"),  # tuple
+        ("a",),
+    ],
+)
+def test_is_seq_true(value):
+    assert _is_seq(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "abc",  # string
+        "",  # empty string
+        None,
+        123,
+        1.23,
+        {"a": 1},  # mapping (not Sequence)
+    ],
+)
+def test_is_seq_false(value):
+    assert _is_seq(value) is False

--- a/tests/test_config_updater.py
+++ b/tests/test_config_updater.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 from experiment_generator.config_updater import ConfigUpdater
 from experiment_generator.tmp_parser.yaml_config import read_yaml
+import warnings
 
 
 def test_update_config_params_update_params_and_jobname_warning(tmp_path, capsys):
@@ -23,8 +24,11 @@ def test_update_config_params_update_params_and_jobname_warning(tmp_path, capsys
         "jobname": "test_jobname",
         "queue": "normal",
     }
+
+    state = {}
+
     with pytest.warns(UserWarning) as record:
-        updater.update_config_params(params, config_path)
+        updater.update_config_params(params, config_path, state)
     assert any(
         "-- jobname must be the same as" in str(f.message) for f in record
     ), "Expected jobaname inconsistency warning not showing!"
@@ -33,3 +37,45 @@ def test_update_config_params_update_params_and_jobname_warning(tmp_path, capsys
 
     assert updated["jobname"] == "test_repo"
     assert updated["queue"] == "normal"
+
+
+def test_update_config_params_no_jobname_no_warning(tmp_path):
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+    config_path = repo_dir / "config.yaml"
+    config_path.write_text("queue: normal\n")
+
+    updater = ConfigUpdater(repo_dir)
+
+    params = {"queue": "express"}
+    state = {}
+
+    # No warning expected
+    updater.update_config_params(params, Path("config.yaml"), state)
+
+    updated = read_yaml(config_path)
+    assert updated["jobname"] == "test_repo"
+    assert updated["queue"] == "express"
+
+
+def test_update_config_params_jobname_matches_no_warning(tmp_path):
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+    rel_path = Path("config.yaml")
+    config_path = repo_dir / rel_path
+    config_path.write_text("jobname: test_repo\nqueue: normal\n")
+
+    updater = ConfigUpdater(repo_dir)
+
+    params = {"jobname": "test_repo", "queue": "express"}
+    state = {}
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        updater.update_config_params(params, rel_path, state)
+
+    assert not any(issubclass(x.category, UserWarning) for x in w)
+
+    updated = read_yaml(config_path.as_posix())
+    assert updated["jobname"] == "test_repo"
+    assert updated["queue"] == "express"

--- a/tests/test_mom6_input_updater.py
+++ b/tests/test_mom6_input_updater.py
@@ -22,6 +22,9 @@ DT_THERM = 7200.0               !   [s] default = 900.0
     )
 
     updater = Mom6InputUpdater(repo_dir)
+
+    state = {}
+
     updater.update_mom6_params(
         {
             "DT": 10,
@@ -29,6 +32,7 @@ DT_THERM = 7200.0               !   [s] default = 900.0
             "DT_THERM": "REMOVE",
         },
         mom_file.name,
+        state,
     )
 
     raw_lines, params = read_mom_input(mom_file)

--- a/tests/test_nuopc_runconfig_updater.py
+++ b/tests/test_nuopc_runconfig_updater.py
@@ -19,6 +19,9 @@ PELAYOUT_attributes::
     )
 
     updater = NuopcRunConfigUpdater(repo_dir)
+
+    state = {}
+
     updater.update_runconfig_params(
         {
             "PELAYOUT_attributes": {
@@ -29,6 +32,7 @@ PELAYOUT_attributes::
             }
         },
         runconfig_path.name,
+        state,
     )
 
     new_nuopc_config = read_nuopc_config(runconfig_path)

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+from experiment_generator.state_store import RemoveStateStore
+
+
+def test_state_path_creates_dir_and_has_expected_filename(tmp_path: Path):
+    store = RemoveStateStore(root_dir=tmp_path)
+
+    p = store.state_path("perturb_1")
+
+    # directory is created as a side-effect
+    assert (tmp_path / store.remove_state_dirname).is_dir()
+    # filename is correct
+    assert p.name == "perturb_1.json"
+    assert p.parent == (tmp_path / store.remove_state_dirname)
+
+
+def test_load_state_missing_file_returns_empty_dict(tmp_path: Path):
+    store = RemoveStateStore(root_dir=tmp_path)
+
+    state = store.load_state("does_not_exist")
+
+    assert state == {}
+
+
+def test_save_then_load_roundtrip(tmp_path: Path):
+    store = RemoveStateStore(root_dir=tmp_path)
+
+    state_in = {
+        "a": 1,
+        "nested": {"x": [1, 2, 3]},
+        "path::REMOVE[0]": "/g/data/foo/bar.nc",
+    }
+
+    store.save_state("perturb_1", state_in)
+
+    fpath = store.state_path("perturb_1")
+    assert fpath.exists()
+
+    # sanity: file is valid JSON
+    parsed = json.loads(fpath.read_text())
+    assert parsed == state_in
+
+    state_out = store.load_state("perturb_1")
+    assert state_out == state_in
+
+
+def test_save_overwrites_existing_file(tmp_path: Path):
+    store = RemoveStateStore(root_dir=tmp_path)
+
+    store.save_state("perturb_1", {"a": 1})
+    store.save_state("perturb_1", {"a": 2, "b": 3})
+
+    assert store.load_state("perturb_1") == {"a": 2, "b": 3}
+
+
+def test_custom_state_dirname(tmp_path: Path):
+    store = RemoveStateStore(root_dir=tmp_path, remove_state_dirname=".my_states")
+
+    store.save_state("perturb_2", {"k": "v"})
+
+    assert (tmp_path / ".my_states").is_dir()
+    assert (tmp_path / ".my_states" / "perturb_2.json").exists()
+    assert store.load_state("perturb_2") == {"k": "v"}


### PR DESCRIPTION
Closes #65 

This PR fixes an issue where positional `REMOVE` in list updates could repeatedly delete additional elements on subsequent runs, in some cases unintentionally removing entire lists. The fix ensures that positional list edits behave consistently across runs.

## After this fix:
As an example, consider a perturbation experiment in[access-om2-configs](https://github.com/ACCESS-NRI/access-om2-configs/blob/fce24e35bdf35720a15b6b03fa3616d3486f50b4/config.yaml#L30-L37). Suppose the goal is to remove the second input file of the ATM component and add an additional input files.

Here, `submodels` is a list of dicts, so positional indexing can be used. This means only the parameters that need to change should be specified, while all other parameters (e.g. `name: atmosphere, model: um, ncpus: 208, exe: um_hg3.exe`) can be omitted in the yaml input file.

Since `input` under `submodels` is also a list, positional indexing applies there as well. In the example below:
- `PRESERVE` keeps the first entry,
- `REMOVE` deletes the second entry, and
- `new/path/to/file1.nc` is appended as a new input.

```
Perturbation_Experiment:
  Parameter_block1:
    branches:
      - perturb_1

    config.yaml:
      submodels:
        - - input:
              - - PRESERVE
                - REMOVE
                - new/path/to/file1.nc
```

## Introduction of `.expt_remove_states`
To ensure positional `REMOVE` operations behave consistently across repeated experiment runs, this update introduces a persistent state json file: `.expt_remove_states/{branch.json}`.

When list-based parameters are modified positionally (e.g. removing the second element of a list), subsequent runs may see the list indices shift. Without tracking this can cause later runs to unintentionally remove additional elements or even wipe out the entire list. The `.expt_remove_states` records which concrete list elements were removed at a given position during the first run. On subsequent runs, those recorded elements are removed explicitly regardless of index shifts. This guarantees that positional removals are independent of list reordering caused by earlier removals.

Edit: users don't need to worry about the `.expt_remove_states` directory. It isn't intended to be modified or committed, so it wont appear when branches are cloned into separate directories.