### PR TITLE
Add support - field_table for MOM5/MOM6

### DIFF
--- a/examples/Experiment_generator_field_table.yaml
+++ b/examples/Experiment_generator_field_table.yaml
@@ -1,0 +1,106 @@
+# Experiment Configuration File
+# This file sets up parameters for both the control and perturbation experiments.
+# Adjust the settings below as needed for your environment and model.
+
+model_type: access-om2 # available models can be checked via `payu list`
+repository_url: git@github.com:ACCESS-NRI/access-om2-configs.git
+start_point: "fce24e3" # Control commit hash for new branches
+test_path: prototype-0.7.0_field_table # All control and perturbation experiment repositories will be created here; can be relative, absolute or ~ (user-defined)
+repository_directory: 1deg_jra55_ryf # Local directory name for the central repository (user-defined)
+
+control_branch_name: ctrl
+
+Control_Experiment:
+  ocean/field_table:
+    temp:  # field name
+      ocean_mod:  # model
+        prog_tracers:  # field_type
+          methods:
+            - REMOVE  # remove `horizontal-advection-scheme = mdppm`
+            - PRESERVE  # keep `vertical-advection-scheme = mdppm`
+            - key: restart_file  # change restart_file with ocean_temp_salt2.res.nc
+              value: ocean_temp_salt2.res.nc
+            - key: ppm_hlimiter # change ppm_hlimiter to 4
+              value: 4
+            # the leftover lines will be preserved automatically
+            # such as "ppm_vlimiter", "3" will be kept
+    sphum:
+      atmos_mod:
+        TRACER:
+          methods:
+            - PRESERVE
+            - PRESERVE
+            - key: profile_type
+              value: fixed
+              params:
+                surface_value: 1e-6
+
+    rayleigh_damp_table:
+      ocean_mod:
+        rayleigh_damp_table:
+          methods:
+            - PRESERVE
+            - PRESERVE
+            - PRESERVE
+            - REMOVE
+            - key: rayleigh
+              value: Torres
+              params:
+                itable: 0
+                jtable: 0
+                ktable_1: 0
+                ktable_2: 0
+                rayleigh_damp_table: 0
+
+
+Perturbation_Experiment:
+  Parameter_block1:
+    branches:
+      - perturb_1
+      # - perturb_2
+
+    ocean/field_table:
+      temp:  # field name
+        ocean_mod:  # model
+          prog_tracers:  # field_type
+            methods:
+              - - REMOVE
+                # - REMOVE
+                # - REMOVE
+                # - REMOVE
+
+      sphum:
+        atmos_mod:
+          TRACER:
+            methods:
+              - - PRESERVE
+                - PRESERVE
+                - key: profile_type
+                  value: fixed
+                  params:
+                    surface_value: 1.5e-6
+
+      rayleigh_damp_table:
+        ocean_mod:
+          rayleigh_damp_table:
+            methods:
+              - - REMOVE
+                - REMOVE
+                - REMOVE
+                - PRESERVE
+                - key: rayleigh
+                  value: Torres
+                  params:
+                    itable: 1
+                    jtable: 1
+                    ktable_1: 1
+                    ktable_2: 1
+                    rayleigh_damp_table: 1
+                - key: rayleigh
+                  value: Torres
+                  params:
+                    itable: 2
+                    jtable: 1
+                    ktable_1: 1
+                    ktable_2: 1
+                    rayleigh_damp_table: 1

--- a/src/experiment_generator/field_table_updater.py
+++ b/src/experiment_generator/field_table_updater.py
@@ -5,6 +5,29 @@ from .tmp_parser.field_table import read_field_table, write_field_table
 from .utils import update_config_entries
 
 
+def prune_empty_field_table_config(config: dict) -> None:
+    """
+    In field_table semantics, an entry with no methods should be removed entirely.
+    """
+    # config[field][model][field_type] = {"methods": [...]}
+    for field in list(config.keys()):
+        field_map = config[field]
+        for model in list(field_map.keys()):
+            model_map = field_map[model]
+            for field_type in list(model_map.keys()):
+                block = model_map[field_type]
+                methods = block.get("methods", None)
+
+                # treat missing methods as no entry
+                if not methods:
+                    del model_map[field_type]
+
+            if not model_map:
+                del field_map[model]
+        if not field_map:
+            del config[field]
+
+
 class FieldTableUpdater:
     def __init__(self, directory: Path) -> None:
         self.directory = directory
@@ -18,4 +41,5 @@ class FieldTableUpdater:
         fpath = self.directory / target_file
         config = read_field_table(fpath)
         update_config_entries(config, param_dict, pop_key=True, path=str(target_file), state=state)
+        prune_empty_field_table_config(config)
         write_field_table(config, fpath)

--- a/src/experiment_generator/field_table_updater.py
+++ b/src/experiment_generator/field_table_updater.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from .tmp_parser.field_table import read_field_table, write_field_table
+
+from .utils import update_config_entries
+
+
+class FieldTableUpdater:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def update_field_table_params(
+        self,
+        param_dict: dict,
+        target_file: str,
+        state: dict,
+    ) -> None:
+        fpath = self.directory / target_file
+        config = read_field_table(fpath)
+        update_config_entries(config, param_dict, pop_key=True, path=str(target_file), state=state)
+        write_field_table(config, fpath)

--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -12,6 +12,7 @@ from .nuopc_runconfig_updater import NuopcRunConfigUpdater
 from .mom6_input_updater import Mom6InputUpdater
 from .nuopc_runseq_updater import NuopcRunseqUpdater
 from .om2_forcing_updater import Om2ForcingUpdater
+from .field_table_updater import FieldTableUpdater
 from .common_var import BRANCH_KEY, _is_removed_str, _is_preserved_str, _is_seq
 from .utils import _strip_preserved
 from .state_store import RemoveStateStore
@@ -57,6 +58,7 @@ class PerturbationExperiment(BaseExperiment):
         self.mom6inputupdater = Mom6InputUpdater(directory)
         self.nuopcrunsequpdater = NuopcRunseqUpdater(directory)
         self.om2forcingupdater = Om2ForcingUpdater(directory)
+        self.fieldtableupdater = FieldTableUpdater(directory)
 
     def _apply_updates(self, file_params: dict[str, dict], state: dict | None = None) -> None:
         """
@@ -81,6 +83,8 @@ class PerturbationExperiment(BaseExperiment):
                 self.nuopcrunsequpdater.update_nuopc_runseq(params, filename, state=state)
             elif filename == "atmosphere/forcing.json":
                 self.om2forcingupdater.update_forcing_params(params, filename, state=state)
+            elif filename.endswith("field_table"):
+                self.fieldtableupdater.update_field_table_params(params, filename, state=state)
 
     def manage_control_expt(self) -> None:
         """

--- a/src/experiment_generator/tmp_parser/field_table.py
+++ b/src/experiment_generator/tmp_parser/field_table.py
@@ -1,0 +1,162 @@
+from pathlib import Path
+import re
+
+
+HEADER_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')
+THREE_STRINGS_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')
+TWO_STRINGS_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')
+ASSIGNMENT_PATTERN = re.compile(r"^\s*([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*)\s*=\s*(.*?)\s*$")
+
+
+def _strip_comments(line: str) -> str:
+    if line.lstrip().startswith("#"):
+        return ""
+    return line.rstrip("\n")
+
+
+def _split_end(line: str) -> tuple[str, bool]:
+    parts = line.rstrip()
+    if parts.endswith("/"):
+        return parts[:-1].rstrip(), True
+    return parts, False
+
+
+def _parse_param_blob(blob: str) -> dict:
+    """
+    Specific for 3-quoted method lines
+    """
+    parts = [p.strip() for p in blob.split(",") if p.strip()]
+    param_dict: dict[str, str] = {}
+    for p in parts:
+        if "=" not in p:
+            return {}
+        key, value = p.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            return {}
+        param_dict[key] = value
+    return param_dict
+
+
+def read_field_table(path) -> dict:
+
+    config = {}
+
+    current_header: tuple[str, str, str] | None = None  # field_type, model, field
+
+    with open(Path(path), "r") as f:
+        for line in f:
+            line = _strip_comments(line)
+
+            if not line.strip():
+                continue
+
+            body, is_end = _split_end(line)
+
+            if current_header is None:
+                header_match = HEADER_PATTERN.match(body)
+                if not header_match:
+                    raise ValueError(f"Expected header (3 quoted strings), got: {line.strip()}")
+                current_header = (header_match.group(1), header_match.group(2), header_match.group(3))
+                methods = []
+                if is_end:
+                    _store_field(config, current_header, methods)
+                    current_header = None
+                continue
+
+            # inside a field definition
+            if body.strip():
+                # 3 strings
+                method_match = THREE_STRINGS_PATTERN.match(body)
+                if method_match:
+                    key, value, blob = method_match.group(1), method_match.group(2), method_match.group(3)
+                    param_dict = _parse_param_blob(blob)
+                    if param_dict:
+                        methods.append({"key": key, "value": value, "params": param_dict})
+                else:
+                    # 2 strings
+                    method_match = TWO_STRINGS_PATTERN.match(body)
+                    if method_match:
+                        methods.append({"key": method_match.group(1), "value": method_match.group(2)})
+                    else:
+                        # this is for assignment format - reading only
+                        method_match = ASSIGNMENT_PATTERN.match(body)
+                        if method_match:
+                            methods.append({"key": method_match.group(1), "value": method_match.group(2)})
+            if is_end:
+                _store_field(config, current_header, methods)
+                current_header = None
+                methods = []
+
+    if current_header is not None:
+        raise ValueError(f"Unclosed entry {current_header} (missing trailing '/' terminator).")
+
+    return config
+
+
+def _store_field(config: dict, header: tuple[str, str, str], methods: list[dict]) -> None:
+    field_type, model, field = header
+
+    if field not in config:
+        config[field] = {}
+    if model not in config[field]:
+        config[field][model] = {}
+    if field_type not in config[field][model]:
+        config[field][model][field_type] = {"methods": []}
+
+    config[field][model][field_type]["methods"].extend(methods)
+
+
+def _params_to_blob(params: dict) -> str:
+    """
+    Convert parameter dictionary to blob string.
+    """
+    parts = []
+    for key in sorted(params.keys()):
+        value = params[key]
+        parts.append(f"{key}={value}")
+    return ", ".join(parts)
+
+
+def write_field_table(config: dict, file: Path) -> None:
+    """
+    Only write in strict 2-quoted / 3-quoted format for consistency.
+
+    - Header: "field_type","model","field"
+    - Method: "key","value" or "key","value","k=v,k2=v2,k3=v3..."
+    - End: '/' on the last line of the entry only
+    """
+    with open(Path(file), "w") as f:
+        first = True  # to manage the first blank line and blank lines between entries
+
+        for field in config.keys():
+            for model in config[field].keys():
+                for field_type in config[field][model].keys():
+                    block = config[field][model][field_type] or {}
+                    # print(block)
+                    methods = block.get("methods", [])
+
+                    if not first:
+                        f.write("\n")
+                    first = False
+
+                    # header must be field_type, model, field
+                    f.write(f'"{field_type}", "{model}", "{field}"\n')
+
+                    if not methods:
+                        f.write(" /\n")
+                        continue
+
+                    for index, method in enumerate(methods):
+                        key = method.get("key")
+                        value = method.get("value")
+                        params = method.get("params", {})
+
+                        if isinstance(params, dict) and params:
+                            blob = _params_to_blob(params)
+                            line = f'"{key}", "{value}", "{blob}"'
+                        else:
+                            line = f'"{key}", "{value}"'
+
+                        f.write(line + ("\n/\n" if index == len(methods) - 1 else "\n"))

--- a/src/experiment_generator/utils.py
+++ b/src/experiment_generator/utils.py
@@ -198,7 +198,7 @@ def _merge_lists_positional(
 
         # If both sides exist and are mappings, recursively merge
         if have_base and isinstance(base0[i], Mapping) and isinstance(c, Mapping):
-            merged = base_list[i]
+            merged = deepcopy(base0[i])
             update_config_entries(merged, c, pop_key=pop_key, path=_path_join(path, f"[{i}]"), state=state)
             if not merged and pop_key:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,11 @@ class Om2forcingRecorder(_RecorderBase):
         self._record("update_forcing_params", params, filename)
 
 
+class FieldTableRecorder(_RecorderBase):
+    def update_field_table_params(self, params, filename, state=None, **kwargs):
+        self._record("update_field_table_params", params, filename)
+
+
 @pytest.fixture(autouse=True)
 def patch_updaters(monkeypatch):
     """
@@ -119,6 +124,7 @@ def patch_updaters(monkeypatch):
     mom6_input_recorder = Mom6Recorder()
     nuopc_runseq_recorder = RunseqRecorder()
     om2_forcing_recorder = Om2forcingRecorder()
+    field_table_recorder = FieldTableRecorder()
 
     monkeypatch.setattr(pert_exp, "F90NamelistUpdater", lambda *_: f90_recorder)
     monkeypatch.setattr(pert_exp, "ConfigUpdater", lambda *_: payuconfig_recorder)
@@ -126,6 +132,7 @@ def patch_updaters(monkeypatch):
     monkeypatch.setattr(pert_exp, "Mom6InputUpdater", lambda *_: mom6_input_recorder)
     monkeypatch.setattr(pert_exp, "NuopcRunseqUpdater", lambda *_: nuopc_runseq_recorder)
     monkeypatch.setattr(pert_exp, "Om2ForcingUpdater", lambda *_: om2_forcing_recorder)
+    monkeypatch.setattr(pert_exp, "FieldTableUpdater", lambda *_: field_table_recorder)
 
     return (
         f90_recorder,
@@ -134,6 +141,7 @@ def patch_updaters(monkeypatch):
         mom6_input_recorder,
         nuopc_runseq_recorder,
         om2_forcing_recorder,
+        field_table_recorder,
     )
 
 

--- a/tests/test_field_table.py
+++ b/tests/test_field_table.py
@@ -1,4 +1,4 @@
-from experiment_generator.field_table_updater import FieldTableUpdater
+from experiment_generator.field_table_updater import FieldTableUpdater, prune_empty_field_table_config
 from experiment_generator.tmp_parser.field_table import read_field_table
 from experiment_generator.common_var import REMOVED, PRESERVED
 
@@ -116,3 +116,25 @@ ppm_vlimiter = 3
     assert after1 == after2, "Field table changed on 2nd identical update!"
 
     assert any(k.endswith("::BASE") for k in state)
+
+
+def test_prune_empty_field_table_config_deletes_empty_entries():
+    config = {
+        "rayleigh_damp_table": {
+            "ocean_mod": {
+                "rayleigh_damp_table": {"methods": []},  # now should be deleted
+            }
+        },
+        "temp": {
+            "ocean_mod": {
+                "prog_tracers": {"methods": [{"key": "k", "value": "v"}]},
+            }
+        },
+    }
+
+    prune_empty_field_table_config(config)
+
+    assert "rayleigh_damp_table" not in config
+    assert "temp" in config
+    assert "ocean_mod" in config["temp"]
+    assert "prog_tracers" in config["temp"]["ocean_mod"]

--- a/tests/test_field_table.py
+++ b/tests/test_field_table.py
@@ -1,0 +1,120 @@
+from experiment_generator.field_table_updater import FieldTableUpdater
+from experiment_generator.tmp_parser.field_table import read_field_table
+from experiment_generator.common_var import REMOVED, PRESERVED
+
+
+def test_update_field_table_params_add_change_remove(tmp_path):
+    repo_dir = tmp_path / "test_repo"
+    repo_dir.mkdir()
+
+    field_table_file = repo_dir / "field_table"
+    field_table_file.write_text(
+        """
+"prog_tracers","ocean_mod","temp"
+horizontal-advection-scheme = mdppm
+vertical-advection-scheme = mdppm
+restart_file  = ocean_temp_salt.res.nc
+ppm_hlimiter = 3
+ppm_vlimiter = 3
+/
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=3.e-6" /
+
+"rayleigh_damp_table","ocean_mod","rayleigh_damp_table"
+"rayleigh","Lombok","itable=36,jtable=112,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
+"rayleigh","Ombai","itable=44,jtable=111,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
+"rayleigh","Torres","itable=62,jtable=106,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
+"rayleigh","Torres","itable=62,jtable=107,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
+"rayleigh","Torres","itable=62,jtable=108,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
+"rayleigh","Torres","itable=62,jtable=109,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"/
+    """
+    )
+
+    updater = FieldTableUpdater(repo_dir)
+
+    param_dict = {
+        "temp": {
+            "ocean_mod": {
+                "prog_tracers": {
+                    "methods": [
+                        PRESERVED,
+                        PRESERVED,
+                        {
+                            "key": "restart_file",
+                            "value": "ocean_temp_salt2.res.nc",
+                        },
+                        {
+                            "key": "ppm_hlimiter",
+                            "value": "4",
+                        },
+                    ]
+                }
+            }
+        },
+        "sphum": {
+            "atmos_mod": {
+                "TRACER": {
+                    "methods": [
+                        PRESERVED,
+                        PRESERVED,
+                        {
+                            "key": "profile_type",
+                            "value": "fixed",
+                            "params": {"surface_value": "1.e-6"},
+                        },
+                    ]
+                }
+            }
+        },
+        "rayleigh_damp_table": {
+            "ocean_mod": {
+                "rayleigh_damp_table": {
+                    "methods": [
+                        PRESERVED,
+                        PRESERVED,
+                        PRESERVED,
+                        REMOVED,
+                        {
+                            "key": "rayleigh",
+                            "value": "Ombai",
+                            "params": {
+                                "itable": "0",
+                                "jtable": "0",
+                                "ktable_1": "0",
+                                "ktable_2": "0",
+                                "rayleigh_damp_table": "0",
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+    }
+
+    state = {}
+
+    # run 1
+    updater.update_field_table_params(
+        param_dict,
+        field_table_file.name,
+        state,
+    )
+
+    after1 = read_field_table(field_table_file)
+
+    # run 2 with same state
+    updater.update_field_table_params(
+        param_dict,
+        field_table_file.name,
+        state,
+    )
+    after2 = read_field_table(field_table_file)
+    assert after1 == after2, "Field table changed on 2nd identical update!"
+
+    # and state should not be empty (BASE snapshots + REMOVE markers)
+    assert any(k.endswith("::BASE") for k in state)
+    assert any("::REMOVE[" in k for k in state)

--- a/tests/test_field_table.py
+++ b/tests/test_field_table.py
@@ -115,6 +115,4 @@ ppm_vlimiter = 3
     after2 = read_field_table(field_table_file)
     assert after1 == after2, "Field table changed on 2nd identical update!"
 
-    # and state should not be empty (BASE snapshots + REMOVE markers)
     assert any(k.endswith("::BASE") for k in state)
-    assert any("::REMOVE[" in k for k in state)

--- a/tests/test_perturbation_experiment.py
+++ b/tests/test_perturbation_experiment.py
@@ -79,6 +79,7 @@ def test_apply_updates_with_correct_updaters(tmp_repo_dir, patch_updaters, indat
         mom6_input_recorder,
         nuopc_runseq_recorder,
         om2_forcing_recorder,
+        field_table_recorder,
     ) = patch_updaters
 
     expt = pert_exp.PerturbationExperiment(directory=tmp_repo_dir, indata=indata)
@@ -100,6 +101,20 @@ def test_apply_updates_with_correct_updaters(tmp_repo_dir, patch_updaters, indat
                             "value": "test_data/temporal.RYF.rsds.1990_1991.nc",
                         }
                     ]
+                }
+            },
+            "field_table": {
+                "temp": {
+                    "ocean_mod": {
+                        "prog_tracers": {
+                            "methods": [
+                                {
+                                    "key": "restart_file",
+                                    "value": "ocean_temp_salt2.res.nc",
+                                }
+                            ]
+                        }
+                    }
                 }
             },
         },
@@ -130,6 +145,24 @@ def test_apply_updates_with_correct_updaters(tmp_repo_dir, patch_updaters, indat
             }
         },
         "atmosphere/forcing.json",
+    )
+    assert field_table_recorder.calls[0] == (
+        "update_field_table_params",
+        {
+            "temp": {
+                "ocean_mod": {
+                    "prog_tracers": {
+                        "methods": [
+                            {
+                                "key": "restart_file",
+                                "value": "ocean_temp_salt2.res.nc",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "field_table",
     )
 
 
@@ -177,7 +210,7 @@ def test_manage_perturb_expt_creat_branches_applies_updates_and_commits(
         directory=tmp_repo_dir, indata={**indata, "Perturbation_Experiment": perturb_block}
     )
 
-    f90_recorder, payuconfig_recorder, _, _, _, _ = patch_updaters
+    f90_recorder, payuconfig_recorder, _, _, _, _, _ = patch_updaters
 
     expt.manage_perturb_expt()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -419,9 +419,8 @@ def test_merge_lists_positional_mapping_branch_uses_current_mapping_slot():
         pop_key=True,
     )
 
-    # Crucial assertion: the merged mapping is literally the same object as base_list[0]
-    # This proves line 203 "merged = base_list[i]" ran.
-    assert out[0] is base_list[0]
+    # out[0] is now a new mapping, not the same as base_list[0]
+    assert out[0] is not base_list[0]
 
     # And content merged as expected
     assert out == [{"a": 1, "keep": 0, "b": 2}]


### PR DESCRIPTION
Closes #5 
Closes #79 

This PR introduces a temporary parser and updater for FMS `field_table`. The implementation supports parsing commonly used 2-quoted, 3-quoted and assignment forms and always write a consistent and quoted-based output format.

More details on the `field_table` format can be found in the comments of [FMS/field_manager/field_manager.F90](https://github.com/NOAA-GFDL/FMS/blob/main/field_manager/field_manager.F90)