### PR TITLE
Support positional REMOVE/PRESERVE markers in control configs

### DIFF
--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -104,6 +104,8 @@ class PerturbationExperiment(BaseExperiment):
                 config_path=self.directory / "config.yaml",
             )
 
+        state = self.state_store.load_state(self.control_branch_name)
+
         # Walk the repo, skipping un-interesting dirs
         exclude_dirs = {".git", ".github", "testing", "docs"}
         for file in self.directory.rglob("*"):
@@ -113,7 +115,10 @@ class PerturbationExperiment(BaseExperiment):
             # eg, ice/cice_in.nml or ice_in.nml
             yaml_data = control_data.get(str(rel_path))
             if yaml_data:
-                self._apply_updates({str(rel_path): yaml_data})
+                self._apply_updates({str(rel_path): yaml_data}, state=state)
+
+        # save state after updates
+        self.state_store.save_state(self.control_branch_name, state)
 
         # Commit if anything actually changed
         modified_files = [item.a_path for item in self.gitrepository.repo.index.diff(None)]

--- a/src/experiment_generator/utils.py
+++ b/src/experiment_generator/utils.py
@@ -198,8 +198,7 @@ def _merge_lists_positional(
 
         # If both sides exist and are mappings, recursively merge
         if have_base and isinstance(base0[i], Mapping) and isinstance(c, Mapping):
-            if i < len(base_list) and isinstance(base_list[i], Mapping):
-                merged = base_list[i]
+            merged = base_list[i]
             update_config_entries(merged, c, pop_key=pop_key, path=_path_join(path, f"[{i}]"), state=state)
             if not merged and pop_key:
                 continue


### PR DESCRIPTION
This is a companion PR to #75, which addressed positional indexing for `REMOVE` and `PRESERVE` markers in perturbation experiments. This PR extends the same logic to control experiments.

In addition, this PR introduces validation checks to ensure that the number of `REMOVE` and/or `PRESERVE` markers does not exceed the number of entries in the original input.