### PR TITLE
Exclude `tmp_parser` from coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+# https://coverage.readthedocs.io/en/latest/source.html#source
+[run]
+omit =
+    src/experiment_generator/tmp_parser/**

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 # https://coverage.readthedocs.io/en/latest/source.html#source
 [run]
+branch = True
+source =
+    src/experiment_generator
 omit =
-    **/src/experiment_generator/tmp_parser/**
+    src/experiment_generator/tmp_parser/**

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 # https://coverage.readthedocs.io/en/latest/source.html#source
 [run]
 omit =
-    src/experiment_generator/tmp_parser/**
+    **/src/experiment_generator/tmp_parser/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,20 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install '.[devel,test]'
+          python3 -m pip install -e '.[devel,test]'
 
       - name: Run tests with coverage
         run: |
           python3 -m pytest -s \
-            --cov=experiment_generator \
-            --cov-branch \
+            --cov \
+            --cov-config=.coveragerc \
             --cov-report=term-missing \
             --cov-report=xml:coverage.xml \
             tests
+
+      - name: Check if tmp_parser is in coverage.xml
+        run: |
+          grep -n "tmp_parser" coverage.xml | head -n 10 || echo "tmp_parser not found in coverage.xml!"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-ignore:
-  # https://docs.codecov.com/docs/ignoring-paths
-  - "src/experiment_generator/tmp_parser/**/*"


### PR DESCRIPTION
Does exactly what the title says.