### PR TITLE
Fix formatting of documentation/hooks/hide_pages_url_segment.py

### DIFF
--- a/documentation/hooks/hide_pages_url_segment.py
+++ b/documentation/hooks/hide_pages_url_segment.py
@@ -1,6 +1,8 @@
 # Change the URL segment for pages in MkDocs to hide the "/pages" prefix, so that pages inside the
 # "pages" directory are served directly at the root URL.
 from mkdocs.plugins import event_priority
+
+
 @event_priority(-100)
 def on_page_markdown(markdown, *, page, config, files):
     if page.file.url.startswith("pages/"):


### PR DESCRIPTION
Same as the title and fix 

```
./documentation/hooks/hide_pages_url_segment.py:4:1: E302 expected 2 blank lines, found 0
./documentation/hooks/hide_pages_url_segment.py:11:61: W292 no newline at end of file
Error: The process '/home/runner/.local/bin/flake8' failed with exit code 1
```