### PR TITLE
Add --version flag to cli

### DIFF
--- a/src/experiment_generator/main.py
+++ b/src/experiment_generator/main.py
@@ -1,8 +1,19 @@
 import argparse
 import os
+from importlib.metadata import version, PackageNotFoundError
 
 from .tmp_parser.yaml_config import read_yaml
 from .experiment_generator import ExperimentGenerator
+
+
+def get_version() -> str:
+    """
+    Retrieve the current version of ACCESS Experiment Generator
+    """
+    try:
+        return version("experiment-generator")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def main():
@@ -19,6 +30,7 @@ def main():
     """
 
     parser = argparse.ArgumentParser(
+        prog="ACCESS Experiment Generator",
         description=(
             "Manage ACCESS experiments using configurable YAML input.\n"
             "If no YAML file is specified, the tool will look for 'Experiment_generator.yaml' "
@@ -36,6 +48,14 @@ def main():
             "Path to the YAML file specifying parameter values for experiment runs.\n"
             "Defaults to 'Experiment_generator.yaml' if present in the current directory."
         ),
+    )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {get_version()}",
+        help="Show the version of ACCESS Experiment Generator",
     )
 
     args = parser.parse_args()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -116,3 +116,14 @@ def test_exec_main(tmp_path, monkeypatch):
 
     assert called.get("run") is True
     assert called["indata"]["model_type"] == VALID_MODELS[0]
+
+
+def test_get_version_fails(monkeypatch):
+    import experiment_generator.main as main_module
+
+    def raise_not_found(_name):
+        raise main_module.PackageNotFoundError
+
+    monkeypatch.setattr(main_module, "version", raise_not_found, raising=True)
+
+    assert main_module.get_version() == "unknown"


### PR DESCRIPTION
This pr adds a `--version / -v ` flag to the experiment-generator command so users can easily check which version they are running.

