### PR TITLE
Formatting-only changes after updating the local Black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
         language_version: python3

--- a/src/experiment_generator/tmp_parser/field_table.py
+++ b/src/experiment_generator/tmp_parser/field_table.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import re
 
-
 HEADER_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')
 THREE_STRINGS_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')
 TWO_STRINGS_PATTERN = re.compile(r'^\s*"([^"]*)"\s*,\s*"([^"]*)"\s*$')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,8 +151,7 @@ def tmp_repo_dir(tmp_path: Path) -> Path:
     (tmp_path / ".github").mkdir()
     (tmp_path / "testing").mkdir()
     (tmp_path / "docs").mkdir()
-    (tmp_path / "config.yaml").write_text(
-        """
+    (tmp_path / "config.yaml").write_text("""
 queue: normal
 ncpus: 240
 jobfs: 10GB
@@ -160,30 +159,24 @@ mem: 960GB
 walltime: 02:00:00
 jobname: 100km_jra55do_ryf
 model: access-om3
-        """
-    )
-    (tmp_path / "input.nml").write_text(
-        """
+        """)
+    (tmp_path / "input.nml").write_text("""
 &MOM_input_nml
     output_directory = './'
     restart_input_dir = './'
     restart_output_dir = './'
     parameter_filename = 'MOM_input', 'MOM_override'
 /
-        """
-    )
-    (tmp_path / "ice_in").write_text(
-        """
+        """)
+    (tmp_path / "ice_in").write_text("""
 &setup_nml
   bfbflag = "off"
   conserv_check = .false.
   diagfreq = 960
   dumpfreq = "x"
   histfreq = "d", "m", "x", "x", "x"
-/        """
-    )
-    (tmp_path / "nuopc.runseq").write_text(
-        """
+/        """)
+    (tmp_path / "nuopc.runseq").write_text("""
 runSeq::
 @3600
   MED med_phases_aofluxes_run
@@ -192,20 +185,16 @@ runSeq::
   MED med_phases_diag_ocn
 @
 ::
-    """
-    )
-    (tmp_path / "nuopc.runconfig").write_text(
-        """
+    """)
+    (tmp_path / "nuopc.runconfig").write_text("""
 component_list: MED ATM ICE OCN ROF
 ALLCOMP_attributes::
      ATM_model = datm
      GLC_model = sglc
      ICE_model = cice
 ::
-        """
-    )
-    (tmp_path / "MOM_input").write_text(
-        """
+        """)
+    (tmp_path / "MOM_input").write_text("""
 THICKNESSDIFFUSE_FIRST = True   !   [Boolean] default = False
                                 ! If true, do thickness diffusion or interface height smoothing before dynamics.
                                 ! This is only used if THICKNESSDIFFUSE or APPLY_INTERFACE_FILTER is true.
@@ -213,11 +202,9 @@ DT = 1800.0                     !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
                                 ! or the coupling timestep in coupled mode.)
-        """
-    )
+        """)
     (tmp_path / "atmosphere").mkdir(parents=True, exist_ok=True)
-    (tmp_path / "atmosphere" / "forcing.json").write_text(
-        """
+    (tmp_path / "atmosphere" / "forcing.json").write_text("""
 {
   "description": "JRA55-do v1.4.0 IAF forcing",
   "inputs": [
@@ -235,6 +222,5 @@ DT = 1800.0                     !   [s]
     }
   ]
 }
-"""
-    )
+""")
     return tmp_path

--- a/tests/test_config_updater.py
+++ b/tests/test_config_updater.py
@@ -10,12 +10,10 @@ def test_update_config_params_update_params_and_jobname_warning(tmp_path, capsys
     rel_path = Path("config.yaml")
     config_path = repo_dir / rel_path
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(
-        """
+    config_path.write_text("""
     jobname: existing_job_name
     queue: normalsr
-    """
-    )
+    """)
 
     updater = ConfigUpdater(repo_dir)
 

--- a/tests/test_field_table.py
+++ b/tests/test_field_table.py
@@ -8,8 +8,7 @@ def test_update_field_table_params_add_change_remove(tmp_path):
     repo_dir.mkdir()
 
     field_table_file = repo_dir / "field_table"
-    field_table_file.write_text(
-        """
+    field_table_file.write_text("""
 "prog_tracers","ocean_mod","temp"
 horizontal-advection-scheme = mdppm
 vertical-advection-scheme = mdppm
@@ -31,8 +30,7 @@ ppm_vlimiter = 3
 "rayleigh","Torres","itable=62,jtable=107,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
 "rayleigh","Torres","itable=62,jtable=108,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"
 "rayleigh","Torres","itable=62,jtable=109,ktable_1=1,ktable_2=50,rayleigh_damp_table=5400"/
-    """
-    )
+    """)
 
     updater = FieldTableUpdater(repo_dir)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,13 +41,11 @@ def test_main_uses_default_yaml_when_present(tmp_path, monkeypatch):
     import experiment_generator.main as main_module
 
     default_yaml = tmp_path / "Experiment_generator.yaml"
-    default_yaml.write_text(
-        f"""
+    default_yaml.write_text(f"""
 repository_directory: test_repo
 control_branch_name: ctrl
 model_type: {VALID_MODELS[1]}
-"""
-    )
+""")
 
     monkeypatch.chdir(tmp_path)
 

--- a/tests/test_mom6_input_updater.py
+++ b/tests/test_mom6_input_updater.py
@@ -7,8 +7,7 @@ def test_update_mom6_params_add_change_remove(tmp_path):
     repo_dir.mkdir()
 
     mom_file = repo_dir / "MOM_input"
-    mom_file.write_text(
-        """
+    mom_file.write_text("""
 DT = 900.0                      !   [s]
                                 ! The (baroclinic) dynamics time step.  The time-step that is actually used will
                                 ! be an integer fraction of the forcing time-step (DT_FORCING in ocean-only mode
@@ -18,8 +17,7 @@ DT_THERM = 7200.0               !   [s] default = 900.0
                                 ! an integer multiple of DT and less than the forcing or coupling time-step,
                                 ! unless THERMO_SPANS_COUPLING is true, in which case DT_THERM can be an integer
                                 ! multiple of the coupling timestep.  By default DT_THERM is set to DT.
-    """
-    )
+    """)
 
     updater = Mom6InputUpdater(repo_dir)
 

--- a/tests/test_nuopc_runconfig_updater.py
+++ b/tests/test_nuopc_runconfig_updater.py
@@ -8,15 +8,13 @@ def test_update_runconfig_params_updates_and_removes(tmp_path):
     repo_dir.mkdir()
 
     runconfig_path = repo_dir / "nuopc.runconfig"
-    runconfig_path.write_text(
-        """
+    runconfig_path.write_text("""
 PELAYOUT_attributes::
      atm_ntasks = 364
      atm_nthreads = 2
      atm_pestride = 2
      atm_rootpe = 0
-    """
-    )
+    """)
 
     updater = NuopcRunConfigUpdater(repo_dir)
 

--- a/tests/test_nuopc_runseq_updater.py
+++ b/tests/test_nuopc_runseq_updater.py
@@ -53,14 +53,12 @@ def test_update_nuopc_runseq_replace_block_only(tmp_path):
         "runSeq::\n" "@1100\n" "  MED do_something\n" "  OCN do_something\n" "@\n" "::\n",
     )
 
-    new_block = dedent(
-        """
+    new_block = dedent("""
         @1.0
           MED do_something2
           OCN
         @
-        """
-    )
+        """)
 
     updater = NuopcRunseqUpdater(repo_dir)
     params = {"runseq_block": new_block}

--- a/tests/test_perturbation_experiment.py
+++ b/tests/test_perturbation_experiment.py
@@ -381,7 +381,7 @@ def test_extract_run_specific_params_raises_on_list_of_dicts_inconsistent_outer_
 def test_apply_updates_strips_preserve_top_level_sets_empty_dict(tmp_repo_dir, indata, patch_updaters):
     # TODO: remove this test when f90nml_updater.update_nml_params uses update_config_entries()
     # after access-parsers implements it.
-    (f90_recorder, *_rest) = patch_updaters
+    f90_recorder, *_rest = patch_updaters
 
     expt = pert_exp.PerturbationExperiment(directory=tmp_repo_dir, indata=indata)
     state = {}
@@ -393,7 +393,7 @@ def test_apply_updates_strips_preserve_top_level_sets_empty_dict(tmp_repo_dir, i
 
 
 def test_apply_updates_hits_namelists_and_unknown_file(tmp_repo_dir, indata, patch_updaters):
-    (f90_recorder, *_rest) = patch_updaters
+    f90_recorder, *_rest = patch_updaters
     expt = pert_exp.PerturbationExperiment(directory=tmp_repo_dir, indata=indata)
 
     state = {}


### PR DESCRIPTION
After updating the local `black` version to match the formatter used in CI, a few scripts required minor reformatting. No logic has been modified.