### PR TITLE
Default control_branch_name to ctrl to avoid ambiguity when unspecified

### DIFF
--- a/src/experiment_generator/base_experiment.py
+++ b/src/experiment_generator/base_experiment.py
@@ -21,7 +21,7 @@ class BaseExperiment:
         self.repo_dir = indata.get("repository_directory")
         self.directory = (self.test_path / self.repo_dir).resolve()
         self.existing_branch = indata.get("existing_branch", None)
-        self.control_branch_name = indata.get("control_branch_name", False)
+        self.control_branch_name = indata.get("control_branch_name", "ctrl")
         self.keep_uuid = indata.get("keep_uuid", False)
 
         # Restart and configuration paths

--- a/tests/test_base_experiment.py
+++ b/tests/test_base_experiment.py
@@ -22,7 +22,7 @@ def test_base_experiment_defaults_and_paths(tmp_path, monkeypatch):
     assert base.repo_dir == "test_repo"
     assert base.directory == (base.test_path / "test_repo").resolve()
     assert base.existing_branch is None
-    assert base.control_branch_name is False
+    assert base.control_branch_name == "ctrl"
     assert base.keep_uuid is False
 
     # Restart and configuration paths


### PR DESCRIPTION
Previously the control branch name defaulted to `False`, which was confusing when not specified. This change replaces it with a meaningful default: `ctrl`.