### PR TITLE
Fix nuopc.runconfig write to file method in tmp_parser

### DIFF
--- a/src/experiment_generator/tmp_parser/nuopc_config.py
+++ b/src/experiment_generator/tmp_parser/nuopc_config.py
@@ -141,4 +141,5 @@ def write_nuopc_config(config: dict, file: Path):
                     stream.write("  " + label + " = " + convert_to_string(value) + "\n")
                 stream.write("::\n\n")
             else:
-                stream.write(key + ": " + convert_to_string(item) + "\n")
+                text = " ".join(map(convert_to_string, item)) if isinstance(item, list) else convert_to_string(item)
+                stream.write(f"{key}: {text}\n")


### PR DESCRIPTION
CLoses #85 

This PR fixes `write_nuopc_config()` by serialising python lists under space-separated values instead of str(list).

