### PR TITLE
Fix broadcast list unwrapping and mixed positional list handling

### DIFF
--- a/src/experiment_generator/perturbation_experiment.py
+++ b/src/experiment_generator/perturbation_experiment.py
@@ -340,6 +340,27 @@ class PerturbationExperiment(BaseExperiment):
                         if isinstance(inner, list) and len(inner) == 0:
                             continue
 
+                        # handle mixed positional inventories, such as [PRESERVE, {input: ...}]
+                        if any(isinstance(d, Mapping) for d in inner):
+                            slots = []
+                            for i in inner:
+                                # keep markers as is
+                                if _is_removed_str(i) or _is_preserved_str(i):
+                                    slots.append(i)
+                                    continue
+
+                                # recurse into dicts
+                                if isinstance(i, Mapping):
+                                    keep_v, cleaned = _filter_value(
+                                        self._extract_run_specific_params(i, indx, total_exps)
+                                    )
+                                    slots.append(cleaned if keep_v else {})
+                                    continue
+
+                                # scalar slots
+                                slots.append(i)
+
+                        # inner is all dicts
                         if all(isinstance(d, Mapping) for d in inner):
                             # recurse for each dict
                             items = []

--- a/src/experiment_generator/utils.py
+++ b/src/experiment_generator/utils.py
@@ -262,6 +262,11 @@ def update_config_entries(
         if not should_apply:
             continue  # no change for this key; keep existing value
 
+        # if the incoming value is a single value list but the base value is scalar,
+        # then treat it as a scalar.
+        if isinstance(v, list) and len(v) == 1 and not isinstance(base.get(k), list):
+            v = v[0]
+
         key_path = _path_join(path, str(k))
 
         if isinstance(v, Mapping) and isinstance(base.get(k), Mapping):

--- a/tests/test_perturbation_experiment.py
+++ b/tests/test_perturbation_experiment.py
@@ -322,6 +322,19 @@ def test_manage_perturb_expt_creat_branches_applies_updates_and_commits(
         # sequence branch: inner list is [PRESERVE]
         ({"queue3": [["PRESERVE"]]}, 0, 2, {"queue3": ["PRESERVE"]}),
         ({"queue3": [["PRESERVE"]]}, 1, 2, {"queue3": ["PRESERVE"]}),
+        # mixed positional list of lists with markers and mappings and scalars
+        (
+            {"submodels": [["PRESERVE", {}, "foo"]]},
+            0,
+            2,
+            {"submodels": ["PRESERVE", None, "foo"]},
+        ),
+        (
+            {"submodels": [["REMOVE", {}, "foo"]]},
+            1,
+            2,
+            {"submodels": ["REMOVE", None, "foo"]},
+        ),
     ],
 )
 def test_extract_run_specific_params_rules(tmp_repo_dir, indata, param_dict, indx, total, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -426,6 +426,16 @@ def test_merge_lists_positional_mapping_branch_uses_current_mapping_slot():
     assert out == [{"a": 1, "keep": 0, "b": 2}]
 
 
+def test_update_config_entries_unwraps_single_item_list_to_scalar_when_base_is_scalar():
+    base = {"ncpus": 4}
+
+    changes = {"ncpus": [8]}  # single-item list
+
+    update_config_entries(base, changes, pop_key=True)
+
+    assert base == {"ncpus": 8}
+
+
 # def test_empty_mapping_in_change_keeps_existing_slot():
 #     base = {"lst": [{"a": 1}, {"b": 2}]}
 #     # empty mapping also means PRESERVE


### PR DESCRIPTION
This is a follow-up fixup PR to #88, which unintentionally corrupted some previously working behaviours.

## 1. single item list broadcasting produces incorrect results

Before this change, when a scalar parameter was provided as a single element yaml list -  a common pattern for broadcasting across multiple branches, the existing generator preserved the list shape instead of unwrapping it to scalar, such as given,
```
    config.yaml:
      walltime:
        - 5:00:00
```
the generator output became,
```
walltime:
  - 5:00:00
```
This is not the intended semantics for scalar parameters. The current PR fixes this issue by treating a single element list as a broadcasted scalar and unwrapping it to,
```
walltime: 5:00:00
```

## 2. Nested yaml list-of-lists handling during list merges
The existing list-merge logic treated an outer list wrapper as a single positional element in the base list, such as,

```
input:
  - - a.nc
    - b.nc
```
was interpreted as replacing the first element of the base list `input[0] with the list [a, b]`, resulting in,
```
input:
  - [a.nc, b.nc]
  - ocean_hgrid.nc
  - ocean_mosaic.nc
 ...
```
This PR fixes the issue by unwrapping the broadcast wrapper from [[a, b]] to [a, b] before merging or cleaning, so the above update now correctly produces,
```
input:
  - a.nc
  - b.nc
  - ocean_mosaic.nc
...
```

## 3. Support mixed positional inventories with PRESERVE / REMOVE markers
For this special case which mixes positional inventories, such as below the inner list does not include all maps inside but can be a special marker (REMOVE / PRESERVE), it does not get per-branch selection correctly.
```
submodels:
  - - PRESERVE
    - input:
        - - a.nc
          - b.nc
```
